### PR TITLE
fix regression where timestamp without alias would contain unnecessary dash

### DIFF
--- a/components/global/CopyComponent.tsx
+++ b/components/global/CopyComponent.tsx
@@ -35,7 +35,7 @@ export const CopyComponent = ({ value, type, label, ...rest }: Props) => {
         id: history.length,
         type: type,
         value,
-        timestamp: new Date().getTime(),
+        timestamp: Date.now(),
       },
     ])
   }

--- a/e2e/aliasedEmail.spec.ts
+++ b/e2e/aliasedEmail.spec.ts
@@ -1,9 +1,9 @@
+import test, { expect } from "@playwright/test"
 import type {
   AliasType,
   CopyHistoryType,
   TotalLocalStorage,
 } from "@/components/types"
-import test, { expect } from "@playwright/test"
 
 const email = "test@example.com"
 const aliasedEmail = "test+SugarFire@example.com"
@@ -57,12 +57,12 @@ test.describe("aliased emails", () => {
 
     for (const key in expectedStorageMap) {
       if (key === "copyHistory") {
-        //@ts-ignore
+        //@ts-expect-error
         const expectedCopyHistory: CopyHistoryType = expectedStorageMap[key]
         const storedCopyHistory: CopyHistoryType = savedLocalStorageMap[key]
         expect(storedCopyHistory).toMatchObject(expectedCopyHistory)
       } else if (key === "aliases") {
-        //@ts-ignore
+        //@ts-expect-error
         const expectedAliases: AliasType[] = expectedStorageMap[key]
         const storedAliases: AliasType[] = savedLocalStorageMap[key]
         expect(storedAliases).toMatchObject(expectedAliases)
@@ -143,7 +143,7 @@ test.describe("aliased emails with timestamp", () => {
     )
     const parsedCopyHistory = copyHistory ? JSON.parse(copyHistory.value) : []
     const timestamp = parsedCopyHistory[0].timestamp
-    const date = new Date(Number.parseInt(timestamp))
+    const date = new Date(Number.parseInt(timestamp, 10))
 
     expect((date.getUTCMinutes() + date.getUTCSeconds()) / 10000).toBeCloseTo(
       (now.getUTCMinutes() + now.getUTCSeconds()) / 10000,

--- a/extensionReqs/manifest.json
+++ b/extensionReqs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AliasIpsum",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "action": {
     "default_popup": "/extension.html",
     "default_title": "AliasIpsum",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "quick-lorem",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "quick-lorem",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "license": "GPL",
       "dependencies": {
         "@emotion/react": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quick-lorem",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "author": {
     "name": "Mikey Villavicencio",
     "email": "mikey.v.dev@gmail.com"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -80,10 +80,19 @@ export default defineConfig({
       },
     },
 
-    // {
-    //   name: "extension firefox",
-    //   use: { ...devices["Desktop Firefox"], baseURL: "http://localhost:3000/extension" },
-    // },
+    {
+      name: "extension firefox",
+      use: {
+        ...devices["Desktop Firefox"],
+        baseURL: "http://localhost:3000/extension",
+        launchOptions: {
+          firefoxUserPrefs: {
+            "dom.events.asyncClipboard.readText": true,
+            "dom.events.testing.asyncClipboard": true,
+          },
+        },
+      },
+    },
 
     // {
     //   name: "extension webkit",

--- a/utils/_aliasEmail.test.ts
+++ b/utils/_aliasEmail.test.ts
@@ -13,11 +13,13 @@ describe("EmailAlias", () => {
     })
 
     it("should create instance with email only and generate default alias", () => {
-      expect(workEmailAlias.getAliasedEmail()).toBe("test+work@example.com")
+      expect(workEmailAlias.getAliasedEmail(false)).toBe(
+        "test+work@example.com"
+      )
     })
 
     it("should handle empty string alias", () => {
-      expect(emptyEmailAlias.getAliasedEmail()).toBe(emailAddress)
+      expect(emptyEmailAlias.getAliasedEmail(false)).toBe(emailAddress)
     })
 
     it("It includes a timestamp when it should for simple aliases", () => {
@@ -25,11 +27,15 @@ describe("EmailAlias", () => {
     })
 
     it("It includes a timestamp when it should for added aliases", () => {
-      expect(workEmailAlias.getAliasedEmail(true)).toContain(timestamp)
+      const timestampedEmail = workEmailAlias.getAliasedEmail(true)
+      expect(timestampedEmail).toContain(timestamp)
+      expect(timestampedEmail).not.toMatch(/test\+-.+@example.com/)
     })
 
     it("It includes a timestamp when it should when alias provided is empty", () => {
-      expect(emptyEmailAlias.getAliasedEmail(true)).toContain(timestamp)
+      const timestampedEmail = emptyEmailAlias.getAliasedEmail(true)
+      expect(timestampedEmail).toContain(timestamp)
+      expect(timestampedEmail).not.toMatch(/test\+-.+@example.com/)
     })
   })
 
@@ -55,6 +61,12 @@ describe("EmailAlias", () => {
       }
     })
 
+    it("should return empty string when email is invalid", () => {
+      const invalidEmail = "invalid-email@"
+
+      expect(new AliasEmail(invalidEmail).getAliasedEmail(true)).toBeFalsy()
+    })
+
     it("should reject emails that already have aliases", () => {
       const aliasedEmails = [
         "user+alias@example.com",
@@ -70,19 +82,21 @@ describe("EmailAlias", () => {
   describe("Alias Generation", () => {
     it("should sanitize alias by replacing spaces with dots", () => {
       const emailAlias = new AliasEmail("user@example.com", "work space")
-      expect(emailAlias.getAliasedEmail()).toBe("user+work.space@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe(
+        "user+work.space@example.com"
+      )
     })
 
     it("should handle multiple spaces in alias", () => {
       const emailAlias = new AliasEmail("user@example.com", "work  space   tag")
-      expect(emailAlias.getAliasedEmail()).toBe(
+      expect(emailAlias.getAliasedEmail(false)).toBe(
         "user+work.space.tag@example.com"
       )
     })
 
     it("should trim whitespace from alias", () => {
       const emailAlias = new AliasEmail("user@example.com", "  work  ")
-      expect(emailAlias.getAliasedEmail()).toBe("user+work@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe("user+work@example.com")
     })
   })
 
@@ -90,24 +104,24 @@ describe("EmailAlias", () => {
     it("should allow updating alias", () => {
       const emailAlias = new AliasEmail("user@example.com", "initial")
 
-      expect(emailAlias.getAliasedEmail()).toBe("user+initial@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe("user+initial@example.com")
 
       emailAlias.setAlias("updated")
 
-      expect(emailAlias.getAliasedEmail()).toBe("user+updated@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe("user+updated@example.com")
     })
 
     it("should handle empty alias update", () => {
       const emailAlias = new AliasEmail("user@example.com", "initial")
       emailAlias.setAlias("")
-      expect(emailAlias.getAliasedEmail()).toBe("user@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe("user@example.com")
     })
   })
 
   describe("Edge Cases", () => {
     it("should handle special characters in alias", () => {
       const emailAlias = new AliasEmail("user@example.com", "work@#$%^&*()")
-      expect(emailAlias.getAliasedEmail()).toBe(
+      expect(emailAlias.getAliasedEmail(false)).toBe(
         "user+work@#$%^&*()@example.com"
       )
     })
@@ -115,17 +129,21 @@ describe("EmailAlias", () => {
     it("should handle very long aliases", () => {
       const longAlias = "a".repeat(100)
       const emailAlias = new AliasEmail("user@example.com", longAlias)
-      expect(emailAlias.getAliasedEmail()).toBe(`user+${longAlias}@example.com`)
+      expect(emailAlias.getAliasedEmail(false)).toBe(
+        `user+${longAlias}@example.com`
+      )
     })
 
     it("should handle unicode characters in email", () => {
       const emailAlias = new AliasEmail("user.name@example.com", "work")
-      expect(emailAlias.getAliasedEmail()).toBe("user.name+work@example.com")
+      expect(emailAlias.getAliasedEmail(false)).toBe(
+        "user.name+work@example.com"
+      )
     })
 
     it("should preserve email case", () => {
       const emailAlias = new AliasEmail("User@Example.COM", "work")
-      expect(emailAlias.getAliasedEmail()).toBe("User+work@Example.COM")
+      expect(emailAlias.getAliasedEmail(false)).toBe("User+work@Example.COM")
     })
   })
 


### PR DESCRIPTION
Add firefox extension to e2e tests
update alias email tests
enforce timestamp boolean on AliasEmail.getAliasedEmail()